### PR TITLE
Updated setup.py and compatible with latest Madmom version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,9 +11,7 @@ setup(name='tapcorrect',
           'madmom',
           'librosa',
           'matplotlib',
-          'numpy',
-          'csv',
-          'pickle'
+          'numpy'
       ],
       include_package_data=True,
       zip_safe=False)

--- a/python/tapcorrect/activation.py
+++ b/python/tapcorrect/activation.py
@@ -1,4 +1,4 @@
-from madmom.features.beats import RNNDownBeatProcessor
+from madmom.features.downbeats import RNNDownBeatProcessor
 import librosa
 import numpy as np
 import pickle


### PR DESCRIPTION
- Removed `csv` and `pickle` packages from `setup.py`, since they come by default.
- Updated code to be compatible with the latest Madmom version (0.16.1).