### PR TITLE
Changing the imports with absolute paths

### DIFF
--- a/python/tapcorrect/__init__.py
+++ b/python/tapcorrect/__init__.py
@@ -1,3 +1,3 @@
-import activation
-import readwrite
-import tapcorrection
+from tapcorrect import activation
+from tapcorrect import readwrite
+from tapcorrect import tapcorrection

--- a/python/tapcorrect/__main__.py
+++ b/python/tapcorrect/__main__.py
@@ -1,4 +1,4 @@
-import tapcorrection
+from tapcorrect import tapcorrection
 
 if __name__ == '__main__':
 

--- a/python/tapcorrect/tapcorrection.py
+++ b/python/tapcorrect/tapcorrection.py
@@ -1,5 +1,5 @@
-import readwrite
-import activation
+from tapcorrect import readwrite
+from tapcorrect import activation
 import numpy as np
 
 def correct_taps(path_taps, path_audio,
@@ -45,7 +45,7 @@ def correct_taps(path_taps, path_audio,
         readwrite.write_beat_annotation(counts_taps, final_beat_times, path_out)
 
     if visualize:
-        import visualization as vis
+        from tapcorrect import visualization as vis
         D_post, list_iois_post = compute_deviation_matrix(act, final_beat_times, fs_act, max_deviation)
 
         vis.visualize_tapcorrection(D_pre, D_post, fs_act,


### PR DESCRIPTION
Hi,

When installing your project with pip:
> pip install 'git+https://github.com/chordify/tapcorrect#subdirectory=python&egg=tapcorrect'

and then running in Python:
> import tapcorrect

I found the error:
>ModuleNotFoundError: No module named 'activation'

I changed the import scheme to use absolute paths instead. I think it is the most elegant solution to allow using tapcorrect in other packages.



